### PR TITLE
feat: add Seleda Finance Flutter clean architecture MVP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Flutter/Dart/Pub related
+**/doc/api/
+.dart_tool/
+.packages
+.pub-cache/
+.pub/
+build/
+.flutter-plugins
+.flutter-plugins-dependencies
+.melior_cache/
+.idea/
+android/.gradle/
+android/app/build/
+ios/Pods/
+*.iml
+*.log
+*.pyc
+.DS_Store
+.macos/
+coverage/
+assets/
+!.gitkeep

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Seleda Finance",
+      "request": "launch",
+      "type": "dart",
+      "program": "lib/main.dart"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,70 @@
-# seleda_mobile
+# Seleda Finance
+
+Seleda Finance is a personal finance MVP built with Flutter using strict Clean Architecture boundaries.
+
+## Features
+- Add income and expense transactions with optional receipt attachments
+- Dashboard with running balance and recent entries
+- Offline-first with local Drift (SQLite) persistence
+- Voice-to-text prefill for transaction forms
+- Riverpod state management and Material 3 UI
+
+## Getting Started
+
+### Prerequisites
+- [Flutter](https://flutter.dev/docs/get-started/install) (stable, Dart 3.x)
+- Android/iOS tooling for your target platform
+
+### Install dependencies
+```bash
+flutter pub get
+```
+
+### Generate Drift database code
+```bash
+dart run build_runner build --delete-conflicting-outputs
+```
+
+### Run the app
+```bash
+flutter run
+```
+
+### Run tests
+```bash
+flutter test
+```
+
+## Project Structure
+```
+lib/
+  app/              # router, theme, dependency injection
+  core/             # cross-cutting utilities (Result, Failure)
+  features/
+    transactions/   # feature modules broken into presentation, application, domain, infrastructure, external
+  shared/           # shared widgets/formatters
+```
+
+## Code Generation
+Drift uses build_runner to generate SQL bindings. Re-run `dart run build_runner build --delete-conflicting-outputs` whenever you modify Drift table definitions.
+
+## Permissions
+- **Android**: update `android/app/src/main/AndroidManifest.xml` with camera, storage, and microphone permissions.
+- **iOS**: add `NSCameraUsageDescription`, `NSPhotoLibraryAddUsageDescription`, and `NSMicrophoneUsageDescription` to `Info.plist`.
+
+If permissions are denied, the voice and image features gracefully degrade.
+
+## Debug Seed Data
+`AppDatabase` seeds three sample transactions the first time it is opened in debug builds to help during development. Remove or adjust this as needed.
+
+## Scripts
+Common tasks:
+- `flutter pub get`
+- `dart run build_runner build --delete-conflicting-outputs`
+- `flutter test`
+- `flutter run`
+
+## Troubleshooting
+- If Drift code generation fails, ensure no editor is locking files and rerun build_runner.
+- For voice-to-text to work on simulators, ensure microphone access is enabled.
+

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,24 @@
+include: package:flutter_lints/flutter.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false
+    prefer_const_constructors: true
+    prefer_final_locals: true
+    avoid_dynamic_calls: true
+    always_use_package_imports: true
+    prefer_const_literals_to_create_immutables: true
+    sort_child_properties_last: true
+    use_super_parameters: true
+    unnecessary_lambdas: true
+
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
+  language:
+    strict-inference: true
+    strict-raw-types: true
+  exclude:
+    - '**/*.g.dart'
+    - '**/*.freezed.dart'

--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      drift_dev:
+        options:
+          data_class_to_companions: true

--- a/lib/app/di.dart
+++ b/lib/app/di.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:seleda_finance/features/transactions/application/usecases/add_transaction.dart';
+import 'package:seleda_finance/features/transactions/application/usecases/compute_balance.dart';
+import 'package:seleda_finance/features/transactions/application/usecases/delete_transaction.dart';
+import 'package:seleda_finance/features/transactions/application/usecases/update_transaction.dart';
+import 'package:seleda_finance/features/transactions/application/usecases/watch_transactions.dart';
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/external/image/image_picker_adapter.dart';
+import 'package:seleda_finance/features/transactions/external/voice/stt_adapter.dart';
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/database.dart';
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/transaction_dao.dart';
+import 'package:seleda_finance/features/transactions/infrastructure/repositories/transaction_repository_impl.dart';
+
+final appDatabaseProvider = Provider<AppDatabase>((ref) {
+  final db = AppDatabase();
+  ref.onDispose(db.close);
+  return db;
+});
+
+final transactionDaoProvider = Provider<TransactionDao>((ref) {
+  final db = ref.watch(appDatabaseProvider);
+  return TransactionDao(db);
+});
+
+final transactionRepositoryProvider = Provider<TransactionRepository>((ref) {
+  final dao = ref.watch(transactionDaoProvider);
+  return TransactionRepositoryImpl(dao);
+});
+
+final addTransactionUseCaseProvider = Provider<AddTransactionUseCase>((ref) {
+  final repo = ref.watch(transactionRepositoryProvider);
+  return AddTransactionUseCase(repo);
+});
+
+final updateTransactionUseCaseProvider = Provider<UpdateTransactionUseCase>((ref) {
+  final repo = ref.watch(transactionRepositoryProvider);
+  return UpdateTransactionUseCase(repo);
+});
+
+final deleteTransactionUseCaseProvider = Provider<DeleteTransactionUseCase>((ref) {
+  final repo = ref.watch(transactionRepositoryProvider);
+  return DeleteTransactionUseCase(repo);
+});
+
+final watchTransactionsUseCaseProvider = Provider<WatchTransactionsUseCase>((ref) {
+  final repo = ref.watch(transactionRepositoryProvider);
+  return WatchTransactionsUseCase(repo);
+});
+
+final computeBalanceUseCaseProvider = Provider<ComputeBalanceUseCase>((ref) {
+  final repo = ref.watch(transactionRepositoryProvider);
+  return ComputeBalanceUseCase(repo);
+});
+
+final imagePickerAdapterProvider = Provider<ImagePickerAdapter>((ref) {
+  return ImagePickerAdapter();
+});
+
+final speechToTextAdapterProvider = Provider<SpeechToTextAdapter>((ref) {
+  return SpeechToTextAdapter();
+});

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/presentation/pages/add_transaction_page.dart';
+import 'package:seleda_finance/features/transactions/presentation/pages/dashboard_page.dart';
+import 'package:seleda_finance/features/transactions/presentation/pages/transactions_page.dart';
+
+final appRouterProvider = Provider<GoRouter>((ref) {
+  return GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        name: 'dashboard',
+        builder: (context, state) => const DashboardPage(),
+      ),
+      GoRoute(
+        path: '/transactions',
+        name: 'transactions',
+        builder: (context, state) => const TransactionsPage(),
+      ),
+      GoRoute(
+        path: '/add',
+        name: 'add',
+        builder: (context, state) {
+          final typeQuery = state.uri.queryParameters['type'];
+          final type = typeQuery != null ? TransactionType.fromName(typeQuery) : TransactionType.expense;
+          final voicePrefill = state.extra is String ? state.extra as String : null;
+          return AddTransactionPage(defaultType: type, voicePrefill: voicePrefill);
+        },
+      ),
+    ],
+  );
+});

--- a/lib/app/theme.dart
+++ b/lib/app/theme.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+
+ThemeData buildLightTheme() {
+  const seedColor = Colors.teal;
+  final colorScheme = ColorScheme.fromSeed(seedColor: seedColor);
+  return ThemeData(
+    colorScheme: colorScheme,
+    useMaterial3: true,
+    appBarTheme: AppBarTheme(
+      backgroundColor: colorScheme.surface,
+      foregroundColor: colorScheme.onSurface,
+      elevation: 0,
+      centerTitle: true,
+    ),
+    floatingActionButtonTheme: FloatingActionButtonThemeData(
+      backgroundColor: colorScheme.primary,
+      foregroundColor: colorScheme.onPrimary,
+    ),
+  );
+}
+
+ThemeData buildDarkTheme() {
+  const seedColor = Colors.teal;
+  final colorScheme = ColorScheme.fromSeed(seedColor: seedColor, brightness: Brightness.dark);
+  return ThemeData(
+    colorScheme: colorScheme,
+    useMaterial3: true,
+  );
+}

--- a/lib/core/error/failure.dart
+++ b/lib/core/error/failure.dart
@@ -1,0 +1,9 @@
+class AppFailure {
+  const AppFailure(this.message, {this.cause});
+
+  final String message;
+  final Object? cause;
+
+  @override
+  String toString() => 'AppFailure(message: $message, cause: $cause)';
+}

--- a/lib/core/result.dart
+++ b/lib/core/result.dart
@@ -1,0 +1,28 @@
+sealed class Result<T, E> {
+  const Result();
+
+  R fold<R>(R Function(T value) onSuccess, R Function(E error) onFailure);
+
+  bool get isSuccess => this is Success<T, E>;
+  bool get isFailure => this is Failure<T, E>;
+}
+
+class Success<T, E> extends Result<T, E> {
+  const Success(this.value);
+
+  final T value;
+
+  @override
+  R fold<R>(R Function(T value) onSuccess, R Function(E error) onFailure) =>
+      onSuccess(value);
+}
+
+class Failure<T, E> extends Result<T, E> {
+  const Failure(this.error);
+
+  final E error;
+
+  @override
+  R fold<R>(R Function(T value) onSuccess, R Function(E error) onFailure) =>
+      onFailure(error);
+}

--- a/lib/features/transactions/application/dto/transaction_input_dto.dart
+++ b/lib/features/transactions/application/dto/transaction_input_dto.dart
@@ -1,0 +1,58 @@
+import 'package:seleda_finance/features/transactions/domain/entities/attachment.dart' as domain;
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart' as domain;
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+
+class TransactionInputDto {
+  TransactionInputDto({
+    this.id,
+    required this.type,
+    required this.amount,
+    required this.dateEpochMs,
+    this.category,
+    this.note,
+    List<AttachmentInputDto>? attachments,
+  }) : attachments = attachments ?? <AttachmentInputDto>[];
+
+  final String? id;
+  final TransactionType type;
+  final Money amount;
+  final int dateEpochMs;
+  final String? category;
+  final String? note;
+  final List<AttachmentInputDto> attachments;
+
+  domain.Transaction toDomain({required String Function() idGenerator}) {
+    final transactionId = id ?? idGenerator();
+    return domain.Transaction(
+      id: transactionId,
+      dateEpochMs: dateEpochMs,
+      type: type,
+      amount: amount,
+      category: category,
+      note: note,
+      attachments: attachments
+          .map(
+            (a) => domain.Attachment(
+              id: a.id ?? idGenerator(),
+              transactionId: transactionId,
+              filePath: a.filePath,
+              mimeType: a.mimeType,
+            ),
+          )
+          .toList(),
+    );
+  }
+}
+
+class AttachmentInputDto {
+  const AttachmentInputDto({
+    this.id,
+    required this.filePath,
+    required this.mimeType,
+  });
+
+  final String? id;
+  final String filePath;
+  final String mimeType;
+}

--- a/lib/features/transactions/application/usecases/add_transaction.dart
+++ b/lib/features/transactions/application/usecases/add_transaction.dart
@@ -1,0 +1,23 @@
+import 'package:uuid/uuid.dart';
+
+import 'package:seleda_finance/core/error/failure.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/application/dto/transaction_input_dto.dart';
+
+class AddTransactionUseCase {
+  AddTransactionUseCase(this._repository, {Uuid? uuid}) : _uuid = uuid ?? const Uuid();
+
+  final TransactionRepository _repository;
+  final Uuid _uuid;
+
+  Future<Result<void, AppFailure>> call(TransactionInputDto input) async {
+    try {
+      final transaction = input.toDomain(idGenerator: _uuid.v4);
+      await _repository.add(transaction);
+      return const Success(null);
+    } catch (error, stackTrace) {
+      return Failure(AppFailure('Unable to add transaction', cause: (error, stackTrace)));
+    }
+  }
+}

--- a/lib/features/transactions/application/usecases/compute_balance.dart
+++ b/lib/features/transactions/application/usecases/compute_balance.dart
@@ -1,0 +1,19 @@
+import 'package:seleda_finance/core/error/failure.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+
+class ComputeBalanceUseCase {
+  ComputeBalanceUseCase(this._repository);
+
+  final TransactionRepository _repository;
+
+  Future<Result<Money, AppFailure>> call() async {
+    try {
+      final cents = await _repository.getBalanceCents();
+      return Success(Money.fromCents(cents));
+    } catch (error, stackTrace) {
+      return Failure(AppFailure('Unable to compute balance', cause: (error, stackTrace)));
+    }
+  }
+}

--- a/lib/features/transactions/application/usecases/delete_transaction.dart
+++ b/lib/features/transactions/application/usecases/delete_transaction.dart
@@ -1,0 +1,18 @@
+import 'package:seleda_finance/core/error/failure.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+
+class DeleteTransactionUseCase {
+  DeleteTransactionUseCase(this._repository);
+
+  final TransactionRepository _repository;
+
+  Future<Result<void, AppFailure>> call(String id) async {
+    try {
+      await _repository.delete(id);
+      return const Success(null);
+    } catch (error, stackTrace) {
+      return Failure(AppFailure('Unable to delete transaction', cause: (error, stackTrace)));
+    }
+  }
+}

--- a/lib/features/transactions/application/usecases/update_transaction.dart
+++ b/lib/features/transactions/application/usecases/update_transaction.dart
@@ -1,0 +1,26 @@
+import 'package:uuid/uuid.dart';
+
+import 'package:seleda_finance/core/error/failure.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/application/dto/transaction_input_dto.dart';
+
+class UpdateTransactionUseCase {
+  UpdateTransactionUseCase(this._repository, {Uuid? uuid}) : _uuid = uuid ?? const Uuid();
+
+  final TransactionRepository _repository;
+  final Uuid _uuid;
+
+  Future<Result<void, AppFailure>> call(TransactionInputDto input) async {
+    if (input.id == null) {
+      return Failure(AppFailure('Transaction id is required for updates'));
+    }
+    try {
+      final transaction = input.toDomain(idGenerator: _uuid.v4);
+      await _repository.update(transaction);
+      return const Success(null);
+    } catch (error, stackTrace) {
+      return Failure(AppFailure('Unable to update transaction', cause: (error, stackTrace)));
+    }
+  }
+}

--- a/lib/features/transactions/application/usecases/watch_transactions.dart
+++ b/lib/features/transactions/application/usecases/watch_transactions.dart
@@ -1,0 +1,26 @@
+import 'dart:async';
+
+import 'package:seleda_finance/core/error/failure.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart';
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/date_range.dart';
+
+class WatchTransactionsUseCase {
+  WatchTransactionsUseCase(this._repository);
+
+  final TransactionRepository _repository;
+
+  Stream<Result<List<Transaction>, AppFailure>> call({
+    DateRange? range,
+    String? category,
+  }) {
+    return _repository.watchAll(range: range, category: category).transform(
+      StreamTransformer.fromHandlers(handleError: (error, stackTrace, sink) {
+        sink.add(Failure(AppFailure('Unable to watch transactions', cause: (error, stackTrace))));
+      }, handleData: (transactions, sink) {
+        sink.add(Success<List<Transaction>, AppFailure>(transactions));
+      }),
+    );
+  }
+}

--- a/lib/features/transactions/domain/entities/attachment.dart
+++ b/lib/features/transactions/domain/entities/attachment.dart
@@ -1,0 +1,13 @@
+class Attachment {
+  Attachment({
+    required this.id,
+    required this.transactionId,
+    required this.filePath,
+    required this.mimeType,
+  });
+
+  final String id;
+  final String transactionId;
+  final String filePath;
+  final String mimeType;
+}

--- a/lib/features/transactions/domain/entities/transaction.dart
+++ b/lib/features/transactions/domain/entities/transaction.dart
@@ -1,0 +1,44 @@
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/domain/entities/attachment.dart';
+
+class Transaction {
+  Transaction({
+    required this.id,
+    required this.dateEpochMs,
+    required this.type,
+    required Money amount,
+    this.category,
+    this.note,
+    List<Attachment>? attachments,
+  })  : assert(amount.cents >= 0, 'Amount must be non-negative'),
+        amount = amount,
+        attachments = List.unmodifiable(attachments ?? <Attachment>[]);
+
+  final String id;
+  final int dateEpochMs;
+  final TransactionType type;
+  final Money amount;
+  final String? category;
+  final String? note;
+  final List<Attachment> attachments;
+
+  Transaction copyWith({
+    int? dateEpochMs,
+    TransactionType? type,
+    Money? amount,
+    String? category,
+    String? note,
+    List<Attachment>? attachments,
+  }) {
+    return Transaction(
+      id: id,
+      dateEpochMs: dateEpochMs ?? this.dateEpochMs,
+      type: type ?? this.type,
+      amount: amount ?? this.amount,
+      category: category ?? this.category,
+      note: note ?? this.note,
+      attachments: attachments ?? this.attachments,
+    );
+  }
+}

--- a/lib/features/transactions/domain/repositories/transaction_repository.dart
+++ b/lib/features/transactions/domain/repositories/transaction_repository.dart
@@ -1,0 +1,10 @@
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/date_range.dart';
+
+abstract class TransactionRepository {
+  Future<void> add(Transaction transaction);
+  Future<void> update(Transaction transaction);
+  Future<void> delete(String id);
+  Stream<List<Transaction>> watchAll({DateRange? range, String? category});
+  Future<int> getBalanceCents();
+}

--- a/lib/features/transactions/domain/value_objects/date_range.dart
+++ b/lib/features/transactions/domain/value_objects/date_range.dart
@@ -1,0 +1,7 @@
+class DateRange {
+  const DateRange({required this.startEpochMs, required this.endEpochMs})
+      : assert(startEpochMs <= endEpochMs, 'Start must be before end');
+
+  final int startEpochMs;
+  final int endEpochMs;
+}

--- a/lib/features/transactions/domain/value_objects/money.dart
+++ b/lib/features/transactions/domain/value_objects/money.dart
@@ -1,0 +1,38 @@
+class Money {
+  const Money._(this.cents);
+
+  final int cents;
+
+  factory Money.fromCents(int cents) {
+    return Money._(cents);
+  }
+
+  factory Money.zero() => const Money._(0);
+
+  factory Money.fromDouble(double amount) {
+    final cents = (amount * 100).round();
+    return Money._(cents);
+  }
+
+  Money operator +(Money other) => Money._(cents + other.cents);
+
+  Money operator -(Money other) => Money._(cents - other.cents);
+
+  Money operator -() => Money._(-cents);
+
+  bool get isNegative => cents < 0;
+
+  bool get isPositive => cents > 0;
+
+  Money abs() => Money._(cents.abs());
+
+  @override
+  int get hashCode => cents.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || other is Money && other.cents == cents;
+
+  @override
+  String toString() => 'Money(${cents / 100})';
+}

--- a/lib/features/transactions/domain/value_objects/transaction_type.dart
+++ b/lib/features/transactions/domain/value_objects/transaction_type.dart
@@ -1,0 +1,14 @@
+enum TransactionType { income, expense;
+
+  String get name => switch (this) {
+        TransactionType.income => 'income',
+        TransactionType.expense => 'expense',
+      };
+
+  static TransactionType fromName(String value) {
+    return TransactionType.values.firstWhere(
+      (type) => type.name == value,
+      orElse: () => TransactionType.expense,
+    );
+  }
+}

--- a/lib/features/transactions/external/image/image_picker_adapter.dart
+++ b/lib/features/transactions/external/image/image_picker_adapter.dart
@@ -1,0 +1,33 @@
+import 'dart:io';
+
+import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class PickedImageResult {
+  const PickedImageResult({required this.filePath, required this.mimeType});
+
+  final String filePath;
+  final String mimeType;
+}
+
+class ImagePickerAdapter {
+  ImagePickerAdapter({ImagePicker? picker}) : _picker = picker ?? ImagePicker();
+
+  final ImagePicker _picker;
+
+  Future<PickedImageResult?> pickImage(ImageSource source) async {
+    final xFile = await _picker.pickImage(source: source, imageQuality: 85);
+    if (xFile == null) {
+      return null;
+    }
+    final directory = await getApplicationDocumentsDirectory();
+    final fileName = p.basename(xFile.path);
+    final destination = File(p.join(directory.path, 'attachments', fileName));
+    await destination.parent.create(recursive: true);
+    await xFile.saveTo(destination.path);
+    final extension = p.extension(destination.path).replaceFirst('.', '');
+    final mimeType = extension.isNotEmpty ? 'image/$extension' : 'image/jpeg';
+    return PickedImageResult(filePath: destination.path, mimeType: mimeType);
+  }
+}

--- a/lib/features/transactions/external/voice/stt_adapter.dart
+++ b/lib/features/transactions/external/voice/stt_adapter.dart
@@ -1,0 +1,32 @@
+import 'dart:async';
+
+import 'package:speech_to_text/speech_to_text.dart' as stt;
+
+class SpeechToTextAdapter {
+  SpeechToTextAdapter({stt.SpeechToText? speech}) : _speech = speech ?? stt.SpeechToText();
+
+  final stt.SpeechToText _speech;
+
+  Future<String?> dictateOnce() async {
+    final available = await _speech.initialize(onError: (error) {}, onStatus: (_) {});
+    if (!available) {
+      return null;
+    }
+    final completer = Completer<String?>();
+    await _speech.listen(
+      onResult: (result) {
+        if (result.finalResult) {
+          completer.complete(result.recognizedWords);
+          _speech.stop();
+        }
+      },
+      listenFor: const Duration(seconds: 5),
+      pauseFor: const Duration(seconds: 3),
+      localeId: 'en_US',
+    );
+    return completer.future.timeout(const Duration(seconds: 10), onTimeout: () {
+      _speech.stop();
+      return null;
+    });
+  }
+}

--- a/lib/features/transactions/infrastructure/data_sources/drift/database.dart
+++ b/lib/features/transactions/infrastructure/data_sources/drift/database.dart
@@ -1,0 +1,70 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter/foundation.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+import 'package:seleda_finance/features/transactions/infrastructure/repositories/transaction_seed.dart';
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/transaction_dao.dart';
+
+part 'database.g.dart';
+
+class Transactions extends Table {
+  TextColumn get id => text()();
+  IntColumn get dateEpochMs => integer()();
+  TextColumn get type => text()();
+  IntColumn get amountCents => integer()();
+  TextColumn get category => text().nullable()();
+  TextColumn get note => text().nullable()();
+
+  @override
+  Set<Column<Object>>? get primaryKey => {id};
+}
+
+class Attachments extends Table {
+  TextColumn get id => text()();
+  TextColumn get transactionId => text()();
+  TextColumn get filePath => text()();
+  TextColumn get mimeType => text()();
+
+  @override
+  Set<Column<Object>>? get primaryKey => {id};
+
+  @override
+  List<String> get customConstraints => ['FOREIGN KEY(transaction_id) REFERENCES transactions(id) ON DELETE CASCADE'];
+}
+
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final dbFile = File(p.join(dir.path, 'seleda_finance.sqlite'));
+    return NativeDatabase.createInBackground(dbFile);
+  });
+}
+
+@DriftDatabase(tables: [Transactions, Attachments], daos: [TransactionDao])
+class AppDatabase extends _$AppDatabase {
+  AppDatabase({bool enableSeed = true})
+      : _enableSeed = enableSeed,
+        super(_openConnection());
+  AppDatabase.forTesting(QueryExecutor executor)
+      : _enableSeed = false,
+        super(executor);
+
+  final bool _enableSeed;
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+        onCreate: (Migrator m) async {
+          await m.createAll();
+          if (kDebugMode && _enableSeed) {
+            await transactionSeed(this);
+          }
+        },
+      );
+}

--- a/lib/features/transactions/infrastructure/data_sources/drift/transaction_dao.dart
+++ b/lib/features/transactions/infrastructure/data_sources/drift/transaction_dao.dart
@@ -1,0 +1,107 @@
+import 'package:drift/drift.dart';
+
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/database.dart';
+
+part 'transaction_dao.g.dart';
+
+class TransactionWithAttachments {
+  TransactionWithAttachments({
+    required this.transaction,
+    required this.attachments,
+  });
+
+  final TransactionData transaction;
+  final List<AttachmentData> attachments;
+}
+
+@DriftAccessor(tables: [Transactions, Attachments])
+class TransactionDao extends DatabaseAccessor<AppDatabase> with _$TransactionDaoMixin {
+  TransactionDao(AppDatabase db) : super(db);
+
+  Future<void> insertTransaction(TransactionsCompanion data, List<AttachmentsCompanion> attachments) async {
+    await transaction(() async {
+      await into(transactions).insertOnConflictUpdate(data);
+      if (attachments.isNotEmpty) {
+        await batch((batch) {
+          batch.insertAllOnConflictUpdate(this.attachments, attachments);
+        });
+      }
+    });
+  }
+
+  Future<void> updateTransaction(TransactionsCompanion data, List<AttachmentsCompanion> attachments) async {
+    await transaction(() async {
+      await into(transactions).insertOnConflictUpdate(data);
+      await (delete(attachmentsTable)..where((tbl) => tbl.transactionId.equals(data.id.value))).go();
+      if (attachments.isNotEmpty) {
+        await batch((batch) {
+          batch.insertAllOnConflictUpdate(this.attachments, attachments);
+        });
+      }
+    });
+  }
+
+  Future<void> deleteTransactionById(String id) async {
+    await transaction(() async {
+      await (delete(attachmentsTable)..where((tbl) => tbl.transactionId.equals(id))).go();
+      await (delete(transactions)..where((tbl) => tbl.id.equals(id))).go();
+    });
+  }
+
+  Stream<List<TransactionWithAttachments>> watchTransactions({
+    String? type,
+    int? startEpochMs,
+    int? endEpochMs,
+    String? category,
+  }) {
+    final query = select(transactions)
+      ..orderBy([
+        (tbl) => OrderingTerm(expression: tbl.dateEpochMs, mode: OrderingMode.desc),
+      ]);
+    if (type != null) {
+      query.where((tbl) => tbl.type.equals(type));
+    }
+    if (startEpochMs != null) {
+      query.where((tbl) => tbl.dateEpochMs.isBiggerOrEqualValue(startEpochMs));
+    }
+    if (endEpochMs != null) {
+      query.where((tbl) => tbl.dateEpochMs.isSmallerOrEqualValue(endEpochMs));
+    }
+    if (category != null) {
+      query.where((tbl) => tbl.category.equals(category));
+    }
+    return query.watch().asyncMap((rows) async {
+      final results = <TransactionWithAttachments>[];
+      for (final row in rows) {
+        final attachmentsData = await (select(attachments)..where((tbl) => tbl.transactionId.equals(row.id))).get();
+        results.add(TransactionWithAttachments(transaction: row, attachments: attachmentsData));
+      }
+      return results;
+    });
+  }
+
+  Future<int> computeBalance() async {
+    final income = await (select(transactions)
+          ..where((tbl) => tbl.type.equals('income')))
+        .map((row) => row.amountCents)
+        .get();
+    final expense = await (select(transactions)
+          ..where((tbl) => tbl.type.equals('expense')))
+        .map((row) => row.amountCents)
+        .get();
+    final incomeSum = income.fold<int>(0, (acc, value) => acc + value);
+    final expenseSum = expense.fold<int>(0, (acc, value) => acc + value);
+    return incomeSum - expenseSum;
+  }
+
+  Future<TransactionWithAttachments?> getTransactionById(String id) async {
+    final transactionData = await (select(transactions)..where((tbl) => tbl.id.equals(id))).getSingleOrNull();
+    if (transactionData == null) {
+      return null;
+    }
+    final attachmentsData = await (select(attachments)..where((tbl) => tbl.transactionId.equals(id))).get();
+    return TransactionWithAttachments(transaction: transactionData, attachments: attachmentsData);
+  }
+
+  Attachments get attachmentsTable => attachments;
+}

--- a/lib/features/transactions/infrastructure/repositories/transaction_repository_impl.dart
+++ b/lib/features/transactions/infrastructure/repositories/transaction_repository_impl.dart
@@ -1,0 +1,112 @@
+import 'package:drift/drift.dart';
+
+import 'package:seleda_finance/features/transactions/domain/entities/attachment.dart' as domain;
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart' as domain;
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/date_range.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/database.dart';
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/transaction_dao.dart';
+
+class TransactionRepositoryImpl implements TransactionRepository {
+  TransactionRepositoryImpl(this._dao);
+
+  final TransactionDao _dao;
+
+  @override
+  Future<void> add(domain.Transaction transaction) async {
+    await _dao.insertTransaction(
+      TransactionsCompanion(
+        id: Value(transaction.id),
+        dateEpochMs: Value(transaction.dateEpochMs),
+        type: Value(transaction.type.name),
+        amountCents: Value(transaction.amount.cents),
+        category: Value(transaction.category),
+        note: Value(transaction.note),
+      ),
+      transaction.attachments
+          .map(
+            (attachment) => AttachmentsCompanion(
+              id: Value(attachment.id),
+              transactionId: Value(attachment.transactionId),
+              filePath: Value(attachment.filePath),
+              mimeType: Value(attachment.mimeType),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  @override
+  Future<void> delete(String id) => _dao.deleteTransactionById(id);
+
+  @override
+  Future<int> getBalanceCents() => _dao.computeBalance();
+
+  @override
+  Stream<List<domain.Transaction>> watchAll({DateRange? range, String? category}) {
+    return _dao
+        .watchTransactions(
+          type: null,
+          startEpochMs: range?.startEpochMs,
+          endEpochMs: range?.endEpochMs,
+          category: category,
+        )
+        .map(
+          (rows) => rows
+              .map(
+                (row) => _mapToDomain(
+                  row.transaction,
+                  row.attachments,
+                ),
+              )
+              .toList(),
+        );
+  }
+
+  @override
+  Future<void> update(domain.Transaction transaction) async {
+    await _dao.updateTransaction(
+      TransactionsCompanion(
+        id: Value(transaction.id),
+        dateEpochMs: Value(transaction.dateEpochMs),
+        type: Value(transaction.type.name),
+        amountCents: Value(transaction.amount.cents),
+        category: Value(transaction.category),
+        note: Value(transaction.note),
+      ),
+      transaction.attachments
+          .map(
+            (attachment) => AttachmentsCompanion(
+              id: Value(attachment.id),
+              transactionId: Value(attachment.transactionId),
+              filePath: Value(attachment.filePath),
+              mimeType: Value(attachment.mimeType),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  domain.Transaction _mapToDomain(TransactionData data, List<AttachmentData> attachments) {
+    return domain.Transaction(
+      id: data.id,
+      dateEpochMs: data.dateEpochMs,
+      type: TransactionType.fromName(data.type),
+      amount: Money.fromCents(data.amountCents),
+      category: data.category,
+      note: data.note,
+      attachments: attachments
+          .map(
+            (attachment) => domain.Attachment(
+              id: attachment.id,
+              transactionId: attachment.transactionId,
+              filePath: attachment.filePath,
+              mimeType: attachment.mimeType,
+            ),
+          )
+          .toList(),
+    );
+  }
+}

--- a/lib/features/transactions/infrastructure/repositories/transaction_seed.dart
+++ b/lib/features/transactions/infrastructure/repositories/transaction_seed.dart
@@ -1,0 +1,38 @@
+import 'package:drift/drift.dart';
+
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/database.dart';
+
+Future<void> transactionSeed(AppDatabase db) async {
+  final count = await db.select(db.transactions).get();
+  if (count.isNotEmpty) {
+    return;
+  }
+  await db.batch((batch) {
+    batch.insertAll(db.transactions, [
+      TransactionsCompanion.insert(
+        id: 'seed-income-1',
+        dateEpochMs: DateTime.now().subtract(const Duration(days: 2)).millisecondsSinceEpoch,
+        type: 'income',
+        amountCents: 500000,
+        category: const Value('Salary'),
+        note: const Value('Welcome bonus'),
+      ),
+      TransactionsCompanion.insert(
+        id: 'seed-expense-1',
+        dateEpochMs: DateTime.now().subtract(const Duration(days: 1)).millisecondsSinceEpoch,
+        type: 'expense',
+        amountCents: 12000,
+        category: const Value('Coffee'),
+        note: const Value('Morning latte'),
+      ),
+      TransactionsCompanion.insert(
+        id: 'seed-expense-2',
+        dateEpochMs: DateTime.now().millisecondsSinceEpoch,
+        type: 'expense',
+        amountCents: 45000,
+        category: const Value('Groceries'),
+        note: const Value('Weekly essentials'),
+      ),
+    ]);
+  });
+}

--- a/lib/features/transactions/presentation/controllers/add_edit_transaction_controller.dart
+++ b/lib/features/transactions/presentation/controllers/add_edit_transaction_controller.dart
@@ -1,0 +1,195 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import 'package:seleda_finance/app/di.dart';
+import 'package:seleda_finance/core/error/failure.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/shared/formatters/money_formatter.dart';
+import 'package:seleda_finance/shared/utils/voice_parser.dart';
+import 'package:seleda_finance/features/transactions/application/dto/transaction_input_dto.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/external/image/image_picker_adapter.dart';
+
+class AttachmentFormEntry {
+  const AttachmentFormEntry({this.id, required this.filePath, required this.mimeType});
+
+  final String? id;
+  final String filePath;
+  final String mimeType;
+}
+
+class AddEditTransactionState {
+  AddEditTransactionState({
+    required this.type,
+    required this.amount,
+    required this.date,
+    required this.category,
+    required this.note,
+    required this.attachments,
+    this.isSaving = false,
+    this.errorMessage,
+    this.successMessage,
+  });
+
+  final TransactionType type;
+  final Money amount;
+  final DateTime date;
+  final String category;
+  final String note;
+  final List<AttachmentFormEntry> attachments;
+  final bool isSaving;
+  final String? errorMessage;
+  final String? successMessage;
+
+  AddEditTransactionState copyWith({
+    TransactionType? type,
+    Money? amount,
+    DateTime? date,
+    String? category,
+    String? note,
+    List<AttachmentFormEntry>? attachments,
+    bool? isSaving,
+    String? errorMessage,
+    String? successMessage,
+  }) {
+    return AddEditTransactionState(
+      type: type ?? this.type,
+      amount: amount ?? this.amount,
+      date: date ?? this.date,
+      category: category ?? this.category,
+      note: note ?? this.note,
+      attachments: attachments ?? this.attachments,
+      isSaving: isSaving ?? this.isSaving,
+      errorMessage: errorMessage,
+      successMessage: successMessage,
+    );
+  }
+}
+
+final addTransactionControllerProvider = StateNotifierProvider.autoDispose<AddEditTransactionController, AddEditTransactionState>((ref) {
+  return AddEditTransactionController(ref);
+});
+
+class AddEditTransactionController extends StateNotifier<AddEditTransactionState> {
+  AddEditTransactionController(this._ref)
+      : super(
+          AddEditTransactionState(
+            type: TransactionType.expense,
+            amount: Money.zero(),
+            date: DateTime.now(),
+            category: '',
+            note: '',
+            attachments: const <AttachmentFormEntry>[],
+          ),
+        );
+
+  final Ref _ref;
+
+  void loadDefaults(TransactionType defaultType, {Money? amount, String? note}) {
+    state = state.copyWith(
+      type: defaultType,
+      amount: amount ?? state.amount,
+      note: note ?? state.note,
+    );
+  }
+
+  void applyVoice(String transcript) {
+    final result = parseVoiceInput(transcript);
+    state = state.copyWith(
+      type: result.type,
+      amount: result.amount ?? state.amount,
+      note: transcript,
+    );
+  }
+
+  void setType(TransactionType type) {
+    state = state.copyWith(type: type);
+  }
+
+  void setAmount(String value) {
+    final normalized = value.replaceAll(',', '').trim();
+    final parsed = double.tryParse(normalized);
+    if (parsed == null) {
+      state = state.copyWith(amount: Money.zero());
+      return;
+    }
+    state = state.copyWith(amount: Money.fromCents((parsed * 100).round()));
+  }
+
+  void setDate(DateTime date) {
+    state = state.copyWith(date: date);
+  }
+
+  void setCategory(String category) {
+    state = state.copyWith(category: category);
+  }
+
+  void setNote(String note) {
+    state = state.copyWith(note: note);
+  }
+
+  Future<void> addAttachment(ImageSource source) async {
+    final picker = _ref.read(imagePickerAdapterProvider);
+    final result = await picker.pickImage(source);
+    if (result == null) {
+      return;
+    }
+    state = state.copyWith(
+      attachments: [
+        ...state.attachments,
+        AttachmentFormEntry(filePath: result.filePath, mimeType: result.mimeType),
+      ],
+    );
+  }
+
+  void removeAttachment(AttachmentFormEntry entry) {
+    state = state.copyWith(
+      attachments: state.attachments.where((e) => e.filePath != entry.filePath).toList(),
+    );
+  }
+
+  Future<Result<void, AppFailure>> submit() async {
+    if (state.amount.cents <= 0) {
+      final failure = AppFailure('Amount must be greater than zero');
+      state = state.copyWith(errorMessage: failure.message, successMessage: null);
+      return Failure(failure);
+    }
+    state = state.copyWith(isSaving: true, errorMessage: null, successMessage: null);
+    final dto = TransactionInputDto(
+      type: state.type,
+      amount: state.amount,
+      dateEpochMs: state.date.millisecondsSinceEpoch,
+      category: state.category.isEmpty ? null : state.category,
+      note: state.note.isEmpty ? null : state.note,
+      attachments: state.attachments
+          .map(
+            (entry) => AttachmentInputDto(
+              filePath: entry.filePath,
+              mimeType: entry.mimeType,
+            ),
+          )
+          .toList(),
+    );
+    final useCase = _ref.read(addTransactionUseCaseProvider);
+    final result = await useCase(dto);
+    return result.fold(
+      (success) {
+        final savedAmount = formatMoney(state.amount, type: state.type);
+        state = state.copyWith(
+          isSaving: false,
+          successMessage: 'Saved $savedAmount',
+          attachments: const <AttachmentFormEntry>[],
+          amount: Money.zero(),
+          note: '',
+          category: '',
+        );
+        return const Success(null);
+      },
+      (failure) {
+        state = state.copyWith(isSaving: false, errorMessage: failure.message);
+        return Failure(failure);
+      },
+    );
+  }
+}

--- a/lib/features/transactions/presentation/controllers/balance_controller.dart
+++ b/lib/features/transactions/presentation/controllers/balance_controller.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:seleda_finance/app/di.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+
+final balanceProvider = StreamProvider<Money>((ref) {
+  final watchUseCase = ref.watch(watchTransactionsUseCaseProvider);
+  final computeUseCase = ref.watch(computeBalanceUseCaseProvider);
+  final controller = StreamController<Money>();
+
+  Future<void> refreshBalance() async {
+    final result = await computeUseCase();
+    result.fold(
+      controller.add,
+      (error) => controller.addError(error, StackTrace.current),
+    );
+  }
+
+  final subscription = watchUseCase().listen((event) {
+    event.fold(
+      (_) => refreshBalance(),
+      (error) => controller.addError(error, StackTrace.current),
+    );
+  });
+
+  ref.onDispose(() {
+    subscription.cancel();
+    controller.close();
+  });
+
+  scheduleMicrotask(refreshBalance);
+
+  return controller.stream;
+});

--- a/lib/features/transactions/presentation/controllers/transaction_list_controller.dart
+++ b/lib/features/transactions/presentation/controllers/transaction_list_controller.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:seleda_finance/app/di.dart';
+import 'package:seleda_finance/core/error/failure.dart';
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+
+class TransactionListState {
+  const TransactionListState({
+    required this.status,
+    this.filter,
+  });
+
+  final AsyncValue<List<Transaction>> status;
+  final TransactionType? filter;
+
+  List<Transaction> get filteredTransactions {
+    final data = status.value ?? <Transaction>[];
+    if (filter == null) {
+      return data;
+    }
+    return data.where((transaction) => transaction.type == filter).toList();
+  }
+
+  TransactionListState copyWith({
+    AsyncValue<List<Transaction>>? status,
+    TransactionType? filter,
+    bool updateFilter = false,
+  }) {
+    return TransactionListState(
+      status: status ?? this.status,
+      filter: updateFilter ? filter : this.filter,
+    );
+  }
+}
+
+final transactionListControllerProvider = StateNotifierProvider<TransactionListController, TransactionListState>((ref) {
+  return TransactionListController(ref)..initialize();
+});
+
+class TransactionListController extends StateNotifier<TransactionListState> {
+  TransactionListController(this._ref)
+      : super(const TransactionListState(status: AsyncValue.loading()));
+
+  final Ref _ref;
+  StreamSubscription<Result<List<Transaction>, AppFailure>>? _subscription;
+
+  void initialize() {
+    final useCase = _ref.read(watchTransactionsUseCaseProvider);
+    _subscription = useCase().listen((event) {
+      event.fold(
+        (transactions) {
+          state = state.copyWith(status: AsyncValue.data(transactions));
+        },
+        (error) {
+          state = state.copyWith(status: AsyncValue.error(error, StackTrace.current));
+        },
+      );
+    });
+  }
+
+  void setFilter(TransactionType? filter) {
+    state = state.copyWith(filter: filter, updateFilter: true);
+  }
+
+  @override
+  void dispose() {
+    _subscription?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/features/transactions/presentation/pages/add_transaction_page.dart
+++ b/lib/features/transactions/presentation/pages/add_transaction_page.dart
@@ -1,0 +1,197 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:intl/intl.dart';
+
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/presentation/controllers/add_edit_transaction_controller.dart';
+
+class AddTransactionPage extends ConsumerStatefulWidget {
+  const AddTransactionPage({
+    super.key,
+    this.defaultType = TransactionType.expense,
+    this.voicePrefill,
+  });
+
+  final TransactionType defaultType;
+  final String? voicePrefill;
+
+  @override
+  ConsumerState<AddTransactionPage> createState() => _AddTransactionPageState();
+}
+
+class _AddTransactionPageState extends ConsumerState<AddTransactionPage> {
+  late final TextEditingController _amountController;
+  late final TextEditingController _categoryController;
+  late final TextEditingController _noteController;
+
+  @override
+  void initState() {
+    super.initState();
+    _amountController = TextEditingController();
+    _categoryController = TextEditingController();
+    _noteController = TextEditingController();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final notifier = ref.read(addTransactionControllerProvider.notifier);
+      notifier.loadDefaults(widget.defaultType);
+      if (widget.voicePrefill != null) {
+        notifier.applyVoice(widget.voicePrefill!);
+      }
+    });
+
+    ref.listen<AddEditTransactionState>(addTransactionControllerProvider, (previous, next) {
+      if (previous?.amount.cents != next.amount.cents) {
+        _amountController.text = (next.amount.cents / 100).toStringAsFixed(2);
+      }
+      if (previous?.category != next.category) {
+        _categoryController.text = next.category;
+      }
+      if (previous?.note != next.note) {
+        _noteController.text = next.note;
+      }
+      if (next.errorMessage != null && next.errorMessage != previous?.errorMessage) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.errorMessage!)),
+        );
+      }
+      if (next.successMessage != null && next.successMessage != previous?.successMessage) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(next.successMessage!)),
+        );
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _amountController.dispose();
+    _categoryController.dispose();
+    _noteController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(addTransactionControllerProvider);
+    final notifier = ref.read(addTransactionControllerProvider.notifier);
+    final dateLabel = DateFormat.yMMMd().format(state.date);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Add Transaction'),
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SegmentedButton<TransactionType>(
+              segments: const [
+                ButtonSegment(value: TransactionType.income, label: Text('Income')),
+                ButtonSegment(value: TransactionType.expense, label: Text('Expense')),
+              ],
+              selected: {state.type},
+              onSelectionChanged: (selection) {
+                notifier.setType(selection.first);
+              },
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _amountController,
+              keyboardType: const TextInputType.numberWithOptions(decimal: true),
+              decoration: const InputDecoration(labelText: 'Amount'),
+              onChanged: notifier.setAmount,
+            ),
+            const SizedBox(height: 16),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Date'),
+              subtitle: Text(dateLabel),
+              trailing: IconButton(
+                icon: const Icon(Icons.calendar_today),
+                onPressed: () async {
+                  final picked = await showDatePicker(
+                    context: context,
+                    initialDate: state.date,
+                    firstDate: DateTime(2000),
+                    lastDate: DateTime(2100),
+                  );
+                  if (picked != null) {
+                    notifier.setDate(picked);
+                  }
+                },
+              ),
+            ),
+            TextField(
+              controller: _categoryController,
+              decoration: const InputDecoration(labelText: 'Category'),
+              onChanged: notifier.setCategory,
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _noteController,
+              decoration: const InputDecoration(labelText: 'Note'),
+              onChanged: notifier.setNote,
+              minLines: 2,
+              maxLines: 4,
+            ),
+            const SizedBox(height: 16),
+            Text('Attachments', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                ElevatedButton.icon(
+                  onPressed: () => notifier.addAttachment(ImageSource.camera),
+                  icon: const Icon(Icons.photo_camera),
+                  label: const Text('Camera'),
+                ),
+                ElevatedButton.icon(
+                  onPressed: () => notifier.addAttachment(ImageSource.gallery),
+                  icon: const Icon(Icons.photo_library),
+                  label: const Text('Gallery'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            if (state.attachments.isEmpty)
+              const Text('No attachments added.')
+            else
+              Wrap(
+                spacing: 8,
+                children: state.attachments
+                    .map(
+                      (attachment) => Chip(
+                        label: Text(attachment.filePath.split('/').last),
+                        onDeleted: () => notifier.removeAttachment(attachment),
+                      ),
+                    )
+                    .toList(),
+              ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: state.isSaving
+                    ? null
+                    : () async {
+                        final result = await notifier.submit();
+                        result.fold(
+                          (_) {},
+                          (error) => ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text(error.message)),
+                          ),
+                        );
+                      },
+                child: state.isSaving
+                    ? const CircularProgressIndicator()
+                    : const Text('Save Transaction'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/transactions/presentation/pages/dashboard_page.dart
+++ b/lib/features/transactions/presentation/pages/dashboard_page.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:go_router/go_router.dart';
+
+import 'package:seleda_finance/app/di.dart';
+import 'package:seleda_finance/shared/formatters/money_formatter.dart';
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/external/voice/stt_adapter.dart';
+import 'package:seleda_finance/features/transactions/presentation/controllers/balance_controller.dart';
+import 'package:seleda_finance/features/transactions/presentation/controllers/transaction_list_controller.dart';
+import 'package:seleda_finance/features/transactions/presentation/widgets/transaction_list_item.dart';
+
+class DashboardPage extends ConsumerWidget {
+  const DashboardPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final balanceAsync = ref.watch(balanceProvider);
+    final transactionState = ref.watch(transactionListControllerProvider);
+    final transactions = transactionState.status.value ?? <Transaction>[];
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Seleda Finance'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.list_alt),
+            onPressed: () => context.push('/transactions'),
+          ),
+        ],
+      ),
+      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      floatingActionButton: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          FloatingActionButton.extended(
+            heroTag: 'income',
+            onPressed: () => context.push('/add?type=income'),
+            icon: const Icon(Icons.add),
+            label: const Text('+ Income'),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'expense',
+            onPressed: () => context.push('/add?type=expense'),
+            icon: const Icon(Icons.remove),
+            label: const Text('+ Expense'),
+          ),
+          const SizedBox(height: 12),
+          FloatingActionButton.extended(
+            heroTag: 'voice',
+            onPressed: () async {
+              final adapter = ref.read(speechToTextAdapterProvider);
+              final transcript = await adapter.dictateOnce();
+              if (transcript == null) {
+                if (context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Voice input unavailable')),
+                  );
+                }
+                return;
+              }
+              if (context.mounted) {
+                context.push('/add', extra: transcript);
+              }
+            },
+            icon: const Icon(Icons.mic),
+            label: const Text('Mic Add'),
+          ),
+        ],
+      ),
+      body: RefreshIndicator(
+        onRefresh: () async {
+          ref.invalidate(transactionListControllerProvider);
+          ref.invalidate(balanceProvider);
+        },
+        child: ListView(
+          padding: const EdgeInsets.all(16),
+          children: [
+            balanceAsync.when(
+              data: (money) => Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text('Balance', style: Theme.of(context).textTheme.titleMedium),
+                      const SizedBox(height: 8),
+                      Text(
+                        formatMoney(money, type: money.cents >= 0 ? TransactionType.income : TransactionType.expense),
+                        style: Theme.of(context).textTheme.displaySmall,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) => Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Text('Error loading balance: $error'),
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            Text('Recent Transactions', style: Theme.of(context).textTheme.titleMedium),
+            const SizedBox(height: 8),
+            if (transactionState.status.isLoading)
+              const Center(child: CircularProgressIndicator())
+            else if (transactions.isEmpty)
+              const Text('No transactions yet.')
+            else
+              ...transactions.take(5).map(
+                (transaction) => TransactionListItem(transaction: transaction),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/transactions/presentation/pages/transactions_page.dart
+++ b/lib/features/transactions/presentation/pages/transactions_page.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:seleda_finance/app/di.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/presentation/controllers/transaction_list_controller.dart';
+import 'package:seleda_finance/features/transactions/presentation/widgets/transaction_list_item.dart';
+
+class TransactionsPage extends ConsumerWidget {
+  const TransactionsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(transactionListControllerProvider);
+    final transactions = state.filteredTransactions;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Transactions'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Wrap(
+              spacing: 8,
+              children: [
+                ChoiceChip(
+                  label: const Text('All'),
+                  selected: state.filter == null,
+                  onSelected: (_) => ref.read(transactionListControllerProvider.notifier).setFilter(null),
+                ),
+                ChoiceChip(
+                  label: const Text('Income'),
+                  selected: state.filter == TransactionType.income,
+                  onSelected: (_) => ref.read(transactionListControllerProvider.notifier).setFilter(TransactionType.income),
+                ),
+                ChoiceChip(
+                  label: const Text('Expense'),
+                  selected: state.filter == TransactionType.expense,
+                  onSelected: (_) => ref.read(transactionListControllerProvider.notifier).setFilter(TransactionType.expense),
+                ),
+              ],
+            ),
+          ),
+          Expanded(
+            child: state.status.when(
+              data: (_) => transactions.isEmpty
+                  ? const Center(child: Text('No transactions found.'))
+                  : ListView.builder(
+                      itemCount: transactions.length,
+                      itemBuilder: (context, index) {
+                        final transaction = transactions[index];
+                        return TransactionListItem(
+                          transaction: transaction,
+                          onDelete: () async {
+                            final useCase = ref.read(deleteTransactionUseCaseProvider);
+                            final result = await useCase(transaction.id);
+                            result.fold(
+                              (_) => ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Transaction deleted')),
+                              ),
+                              (error) => ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('Error deleting: ${error.message}')),
+                              ),
+                            );
+                          },
+                        );
+                      },
+                    ),
+              loading: () => const Center(child: CircularProgressIndicator()),
+              error: (error, _) => Center(child: Text('Error: $error')),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/transactions/presentation/widgets/transaction_list_item.dart
+++ b/lib/features/transactions/presentation/widgets/transaction_list_item.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+
+import 'package:seleda_finance/shared/formatters/money_formatter.dart';
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+
+class TransactionListItem extends StatelessWidget {
+  const TransactionListItem({
+    super.key,
+    required this.transaction,
+    this.onDelete,
+  });
+
+  final Transaction transaction;
+  final VoidCallback? onDelete;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final isIncome = transaction.type == TransactionType.income;
+    final amountText = formatMoney(transaction.amount, type: transaction.type);
+    return Card(
+      child: ListTile(
+        leading: CircleAvatar(
+          backgroundColor: isIncome ? colorScheme.secondaryContainer : colorScheme.errorContainer,
+          child: Icon(
+            isIncome ? Icons.arrow_downward : Icons.arrow_upward,
+            color: isIncome ? colorScheme.onSecondaryContainer : colorScheme.onErrorContainer,
+          ),
+        ),
+        title: Text(transaction.category ?? (isIncome ? 'Income' : 'Expense')),
+        subtitle: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (transaction.note != null && transaction.note!.isNotEmpty)
+              Text(transaction.note!),
+            Text(
+              DateTime.fromMillisecondsSinceEpoch(transaction.dateEpochMs).toIso8601String().split('T').first,
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            if (transaction.attachments.isNotEmpty)
+              Text('${transaction.attachments.length} attachment(s)', style: Theme.of(context).textTheme.bodySmall),
+          ],
+        ),
+        trailing: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            Text(
+              amountText,
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    color: isIncome ? colorScheme.primary : colorScheme.error,
+                  ),
+            ),
+            if (onDelete != null)
+              IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: onDelete,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:seleda_finance/app/di.dart';
+import 'package:seleda_finance/app/router.dart';
+import 'package:seleda_finance/app/theme.dart';
+
+void main() {
+  WidgetsFlutterBinding.ensureInitialized();
+  runApp(const ProviderScope(child: SeledaApp()));
+}
+
+class SeledaApp extends ConsumerWidget {
+  const SeledaApp({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final router = ref.watch(appRouterProvider);
+    return MaterialApp.router(
+      title: 'Seleda Finance',
+      theme: buildLightTheme(),
+      darkTheme: buildDarkTheme(),
+      routerConfig: router,
+      debugShowCheckedModeBanner: false,
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale('en')],
+    );
+  }
+}

--- a/lib/shared/formatters/money_formatter.dart
+++ b/lib/shared/formatters/money_formatter.dart
@@ -1,0 +1,12 @@
+import 'package:intl/intl.dart';
+
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+
+final _currencyFormat = NumberFormat.currency(locale: 'en_US', symbol: r'$');
+
+String formatMoney(Money money, {TransactionType? type}) {
+  final amount = money.cents / 100;
+  final prefix = type == TransactionType.expense ? '-' : '';
+  return '$prefix${_currencyFormat.format(amount.abs())}';
+}

--- a/lib/shared/utils/voice_parser.dart
+++ b/lib/shared/utils/voice_parser.dart
@@ -1,0 +1,27 @@
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+
+class VoiceParseResult {
+  VoiceParseResult({this.amount, required this.type});
+
+  final Money? amount;
+  final TransactionType type;
+}
+
+VoiceParseResult parseVoiceInput(String input) {
+  final normalized = input.toLowerCase();
+  final isIncome = ['income', 'salary', 'received'].any(normalized.contains);
+  final type = isIncome ? TransactionType.income : TransactionType.expense;
+  final match = RegExp(r'(\d+[\.,]?\d{0,2})').firstMatch(normalized);
+  if (match == null) {
+    return VoiceParseResult(amount: null, type: type);
+  }
+  final raw = match.group(0)!.replaceAll(',', '.');
+  final sanitized = raw.replaceAll(RegExp('[^0-9\.]'), '');
+  final parsed = double.tryParse(sanitized);
+  if (parsed == null) {
+    return VoiceParseResult(amount: null, type: type);
+  }
+  final cents = (parsed * 100).round();
+  return VoiceParseResult(amount: Money.fromCents(cents), type: type);
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,35 @@
+name: seleda_finance
+description: Seleda Finance personal finance MVP with Clean Architecture
+publish_to: 'none'
+version: 0.1.0+1
+environment:
+  sdk: '>=3.2.0 <4.0.0'
+  flutter: '>=3.16.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+  cupertino_icons: ^1.0.6
+  flutter_riverpod: ^2.4.9
+  go_router: ^12.1.1
+  drift: ^2.13.0
+  drift_flutter: ^2.13.0
+  path_provider: ^2.1.2
+  path: ^1.9.0
+  image_picker: ^1.0.7
+  speech_to_text: ^6.3.0
+  intl: ^0.19.0
+  uuid: ^4.2.2
+  collection: ^1.18.0
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^3.0.1
+  mocktail: ^1.0.2
+  drift_dev: ^2.13.0
+  build_runner: ^2.4.8
+flutter:
+  uses-material-design: true
+  assets:
+    - assets/

--- a/test/unit/application/usecases_test.dart
+++ b/test/unit/application/usecases_test.dart
@@ -1,0 +1,114 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:seleda_finance/core/result.dart';
+import 'package:seleda_finance/features/transactions/application/dto/transaction_input_dto.dart';
+import 'package:seleda_finance/features/transactions/application/usecases/add_transaction.dart';
+import 'package:seleda_finance/features/transactions/application/usecases/compute_balance.dart';
+import 'package:seleda_finance/features/transactions/application/usecases/delete_transaction.dart';
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart' as domain;
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/date_range.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+
+class _FakeTransactionRepository implements TransactionRepository {
+  final _transactions = <domain.Transaction>[];
+  final _controller = StreamController<List<domain.Transaction>>.broadcast();
+
+  void _emit() => _controller.add(List.unmodifiable(_transactions));
+
+  @override
+  Future<void> add(domain.Transaction transaction) async {
+    _transactions.add(transaction);
+    _emit();
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _transactions.removeWhere((transaction) => transaction.id == id);
+    _emit();
+  }
+
+  @override
+  Future<int> getBalanceCents() async {
+    var total = 0;
+    for (final transaction in _transactions) {
+      total += transaction.type == TransactionType.income
+          ? transaction.amount.cents
+          : -transaction.amount.cents;
+    }
+    return total;
+  }
+
+  @override
+  Future<void> update(domain.Transaction transaction) async {}
+
+  @override
+  Stream<List<domain.Transaction>> watchAll({DateRange? range, String? category}) => _controller.stream;
+}
+
+void main() {
+  group('Usecases', () {
+    late _FakeTransactionRepository repository;
+
+    setUp(() {
+      repository = _FakeTransactionRepository();
+    });
+
+    test('add transaction usecase stores data', () async {
+      final usecase = AddTransactionUseCase(repository);
+      final dto = TransactionInputDto(
+        type: TransactionType.income,
+        amount: Money.fromCents(1000),
+        dateEpochMs: DateTime(2023, 1, 1).millisecondsSinceEpoch,
+      );
+
+      final result = await usecase(dto);
+
+      expect(result.isSuccess, isTrue);
+      expect(repository.watchAll().first, completion(isNotEmpty));
+    });
+
+    test('delete transaction usecase removes data', () async {
+      final add = AddTransactionUseCase(repository);
+      final delete = DeleteTransactionUseCase(repository);
+      final dto = TransactionInputDto(
+        type: TransactionType.expense,
+        amount: Money.fromCents(500),
+        dateEpochMs: DateTime(2023, 1, 1).millisecondsSinceEpoch,
+      );
+      final addResult = await add(dto);
+      expect(addResult.isSuccess, isTrue);
+      final stored = await repository.watchAll().first;
+      final id = stored.first.id;
+
+      final deleteResult = await delete(id);
+      expect(deleteResult.isSuccess, isTrue);
+      expect(repository.watchAll().first, completion(isEmpty));
+    });
+
+    test('compute balance aggregates correctly', () async {
+      final add = AddTransactionUseCase(repository);
+      final compute = ComputeBalanceUseCase(repository);
+
+      await add(TransactionInputDto(
+        type: TransactionType.income,
+        amount: Money.fromCents(2000),
+        dateEpochMs: DateTime.now().millisecondsSinceEpoch,
+      ));
+      await add(TransactionInputDto(
+        type: TransactionType.expense,
+        amount: Money.fromCents(500),
+        dateEpochMs: DateTime.now().millisecondsSinceEpoch,
+      ));
+
+      final result = await compute();
+      result.fold(
+        (money) => expect(money.cents, 1500),
+        (failure) => fail('Expected success but got $failure'),
+      );
+    });
+  });
+}

--- a/test/unit/domain/money_test.dart
+++ b/test/unit/domain/money_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+
+void main() {
+  group('Money', () {
+    test('adds values correctly', () {
+      final first = Money.fromCents(500);
+      final second = Money.fromCents(250);
+
+      expect((first + second).cents, 750);
+    });
+
+    test('subtracts values correctly', () {
+      final first = Money.fromCents(1000);
+      final second = Money.fromCents(400);
+
+      expect((first - second).cents, 600);
+    });
+
+    test('negation works', () {
+      final money = Money.fromCents(200);
+
+      expect((-money).cents, -200);
+    });
+  });
+}

--- a/test/unit/domain/transaction_test.dart
+++ b/test/unit/domain/transaction_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/money.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+
+void main() {
+  test('transaction rejects negative amounts', () {
+    expect(
+      () => Transaction(
+        id: 't1',
+        dateEpochMs: DateTime.now().millisecondsSinceEpoch,
+        type: TransactionType.expense,
+        amount: Money.fromCents(-100),
+      ),
+      throwsA(isA<AssertionError>()),
+    );
+  });
+}

--- a/test/unit/infrastructure/transaction_dao_test.dart
+++ b/test/unit/infrastructure/transaction_dao_test.dart
@@ -1,0 +1,73 @@
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/database.dart';
+import 'package:seleda_finance/features/transactions/infrastructure/data_sources/drift/transaction_dao.dart';
+
+void main() {
+  late AppDatabase db;
+  late TransactionDao dao;
+
+  setUp(() async {
+    db = AppDatabase.forTesting(NativeDatabase.memory());
+    dao = TransactionDao(db);
+    await db.customStatement('PRAGMA foreign_keys = ON');
+  });
+
+  tearDown(() async {
+    await db.close();
+  });
+
+  test('insert and watch transactions', () async {
+    await dao.insertTransaction(
+      TransactionsCompanion(
+        id: const Value('1'),
+        dateEpochMs: Value(DateTime(2023, 1, 1).millisecondsSinceEpoch),
+        type: const Value('income'),
+        amountCents: const Value(1000),
+        category: const Value('Salary'),
+        note: const Value('January'),
+      ),
+      [
+        AttachmentsCompanion(
+          id: const Value('a1'),
+          transactionId: const Value('1'),
+          filePath: const Value('/path/receipt.jpg'),
+          mimeType: const Value('image/jpeg'),
+        ),
+      ],
+    );
+
+    final stream = dao.watchTransactions();
+    final result = await stream.first;
+    expect(result, isNotEmpty);
+    expect(result.first.attachments.length, 1);
+  });
+
+  test('delete cascades attachments', () async {
+    await dao.insertTransaction(
+      TransactionsCompanion(
+        id: const Value('1'),
+        dateEpochMs: Value(DateTime(2023, 1, 1).millisecondsSinceEpoch),
+        type: const Value('expense'),
+        amountCents: const Value(500),
+        category: const Value('Food'),
+        note: const Value('Lunch'),
+      ),
+      [
+        AttachmentsCompanion(
+          id: const Value('a1'),
+          transactionId: const Value('1'),
+          filePath: const Value('/path/receipt.jpg'),
+          mimeType: const Value('image/jpeg'),
+        ),
+      ],
+    );
+
+    await dao.deleteTransactionById('1');
+
+    final attachmentsCount = await db.select(db.attachments).get();
+    expect(attachmentsCount, isEmpty);
+  });
+}

--- a/test/widget/transactions/add_and_list_test.dart
+++ b/test/widget/transactions/add_and_list_test.dart
@@ -1,0 +1,126 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:seleda_finance/app/di.dart';
+import 'package:seleda_finance/features/transactions/domain/entities/transaction.dart' as domain;
+import 'package:seleda_finance/features/transactions/domain/repositories/transaction_repository.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/date_range.dart';
+import 'package:seleda_finance/features/transactions/domain/value_objects/transaction_type.dart';
+import 'package:seleda_finance/features/transactions/external/image/image_picker_adapter.dart';
+import 'package:seleda_finance/features/transactions/external/voice/stt_adapter.dart';
+import 'package:seleda_finance/features/transactions/presentation/pages/add_transaction_page.dart';
+import 'package:seleda_finance/features/transactions/presentation/pages/dashboard_page.dart';
+import 'package:seleda_finance/features/transactions/presentation/pages/transactions_page.dart';
+
+class _FakeRepository implements TransactionRepository {
+  _FakeRepository() : _controller = StreamController<List<domain.Transaction>>.broadcast() {
+    _controller.onListen = _emit;
+  }
+
+  final _transactions = <domain.Transaction>[];
+  final StreamController<List<domain.Transaction>> _controller;
+
+  void _emit() => _controller.add(List.unmodifiable(_transactions));
+
+  @override
+  Future<void> add(domain.Transaction transaction) async {
+    _transactions.add(transaction);
+    _emit();
+  }
+
+  @override
+  Future<void> delete(String id) async {
+    _transactions.removeWhere((transaction) => transaction.id == id);
+    _emit();
+  }
+
+  @override
+  Future<int> getBalanceCents() async {
+    var total = 0;
+    for (final transaction in _transactions) {
+      total += transaction.type == TransactionType.income
+          ? transaction.amount.cents
+          : -transaction.amount.cents;
+    }
+    return total;
+  }
+
+  @override
+  Future<void> update(domain.Transaction transaction) async {
+    final index = _transactions.indexWhere((item) => item.id == transaction.id);
+    if (index != -1) {
+      _transactions[index] = transaction;
+      _emit();
+    }
+  }
+
+  @override
+  Stream<List<domain.Transaction>> watchAll({DateRange? range, String? category}) {
+    return _controller.stream;
+  }
+}
+
+class _FakeImagePicker extends ImagePickerAdapter {}
+
+class _FakeSpeechAdapter extends SpeechToTextAdapter {
+  @override
+  Future<String?> dictateOnce() async => null;
+}
+
+void main() {
+  testWidgets('adding and deleting transactions updates UI', (tester) async {
+    final repository = _FakeRepository();
+    final container = ProviderContainer(
+      overrides: [
+        transactionRepositoryProvider.overrideWithValue(repository),
+        imagePickerAdapterProvider.overrideWithValue(_FakeImagePicker()),
+        speechToTextAdapterProvider.overrideWithValue(_FakeSpeechAdapter()),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: AddTransactionPage(defaultType: TransactionType.income),
+        ),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField).first, '50');
+    await tester.enterText(find.widgetWithText(TextField, 'Category'), 'Freelance');
+    await tester.enterText(find.widgetWithText(TextField, 'Note'), 'Side gig');
+    await tester.tap(find.text('Save Transaction'));
+    await tester.pumpAndSettle();
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: TransactionsPage()),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('Freelance'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.delete_outline));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Freelance'), findsNothing);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(home: DashboardPage()),
+      ),
+    );
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.textContaining('Balance'), findsOneWidget);
+    expect(find.textContaining('0.00'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold the Seleda Finance Flutter application with clean architecture layers, Riverpod DI, routing, theming, and shared utilities
- implement the transactions feature end-to-end with Drift persistence, image/voice adapters, presentation controllers, and Material 3 UI flows
- add result/failure core types plus comprehensive unit and widget tests covering domain, application, infrastructure, and presentation behavior

## Testing
- flutter test *(not run: Flutter SDK unavailable in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0dad93968832cb59dd9602639fbdb